### PR TITLE
Fix external shared example missing specs bug

### DIFF
--- a/spec/shared_example_spec.rb
+++ b/spec/shared_example_spec.rb
@@ -1,8 +1,8 @@
 require 'rspec'
 
-require_relative './support/shared_examples/foo'
+require_relative './support/shared_examples/from_another_file'
 
-RSpec.describe "Example Group" do
-  include_examples "foo", "foo"
-  include_examples "foo", "bar"
+RSpec.describe "Shared Examples" do
+  include_examples "from another file", :should_pass
+  include_examples "from another file", :should_fail
 end

--- a/spec/support/shared_examples/foo.rb
+++ b/spec/support/shared_examples/foo.rb
@@ -1,7 +1,0 @@
-require 'rspec'
-
-RSpec.shared_examples "foo" do |arg|
-  it "works" do
-    expect("foo").to eq(arg)
-  end
-end

--- a/spec/support/shared_examples/from_another_file.rb
+++ b/spec/support/shared_examples/from_another_file.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+
+RSpec.shared_examples "from another file" do |expected|
+  it "works" do
+    #-> Given a shared example with spec
+    expect(expected).to eq(:should_pass)
+  end
+end


### PR DESCRIPTION
With:

```ruby
# spec/shared_example_spec.rb
RSpec.describe "Example Group Including Examples" do
  include_examples "from another file", :should_pass
  include_examples "from another file", :should_fail
end

# spec/support/shared_examples/from_another_file.rb
RSpec.shared_examples "from another file" do |expected|
  it "works" do
    #-> Given a shared example with spec
    expect(expected).to eq(:should_pass)
  end
end
```

Before:
<img width="892" alt="screen shot 2018-09-10 at 8 14 16 pm" src="https://user-images.githubusercontent.com/133218/45335925-37925b00-b536-11e8-8de6-48d3b217bb85.png">

After:
<img width="889" alt="screen shot 2018-09-10 at 8 14 38 pm" src="https://user-images.githubusercontent.com/133218/45335929-3e20d280-b536-11e8-97b3-84767d7b031b.png">

I originally ran into [Issue #6](https://github.com/vbanthia/rspec_html_reporter/issues/6) and was going to submit this PR for that. I saw the quickfix https://github.com/vbanthia/rspec_html_reporter/commit/7d83b67979feb595ff74911f0bb8593aa7a794f9 for that issue, but noticed that the fundamental examples-from-different-files bug was not fully addressed.

I do so in this PR by determining whether the next example is indeed "lexically next" where the original code did not:

```ruby
        lexically_next = next_ex &&
          next_ex.file_path == ex.file_path &&
          next_ex.metadata[:line_number] > ex.metadata[:line_number]
```

I've also done some opportunistic cleanup & readability refactoring.