### PR TITLE
Customize for turnip test case.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format RspecHtmlReporter
+-r turnip/rspec

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development do
   gem "rdoc", "~> 3.12"
   gem "bundler", "~> 1.0"
   gem "jeweler", "~> 2.0.1"
+  gem 'turnip', '~> 2.0', '>= 2.0.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
     diff-lcs (1.2.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    gherkin (2.12.2-x86-mingw32)
+      multi_json (~> 1.3)
     git (1.2.8)
     github_api (0.12.0)
       addressable (~> 2.3)
@@ -70,6 +74,9 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.3)
     thread_safe (0.3.4)
+    turnip (2.1.1)
+      gherkin (~> 2.5)
+      rspec (>= 3.0, < 4.0)
     tzinfo (1.2.1)
       thread_safe (~> 0.1)
 
@@ -85,3 +92,7 @@ DEPENDENCIES
   rouge (= 1.6.1)
   rspec (~> 3.0.0)
   rspec-core (>= 3.0.3)
+  turnip (~> 2.0, >= 2.0.2)
+
+BUNDLED WITH
+   1.16.4

--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -52,7 +52,7 @@ class Oopsy
   end
 
   def process_source
-    data = @backtrace_message[0].split(':')
+    data = @backtrace_message.first.split(':')
     unless data.empty?
     if os == :windows
       file_path = data[0] + ':' + data[1]

--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -20,7 +20,7 @@ class Oopsy
       @klass = @exception.class
       @message = @exception.message.encode('utf-8')
       @backtrace = @exception.backtrace
-      @backtrace_message = formatted_backtrace(@example,@exception)
+      @backtrace_message = formatted_backtrace(@example, @exception)
       @highlighted_source = process_source
       @explanation = process_message
     end

--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -12,14 +12,15 @@ I18n.enforce_available_locales = false
 class Oopsy
   attr_reader :klass, :message, :backtrace, :highlighted_source, :explanation, :backtrace_message
 
-  def initialize(exception, file_path)
-    @exception = exception
+  def initialize(example, file_path)
+    @example = example
+    @exception = @example.exception
     @file_path = file_path
     unless @exception.nil?
       @klass = @exception.class
       @message = @exception.message.encode('utf-8')
       @backtrace = @exception.backtrace
-      @backtrace_message = @backtrace.nil? ? '' : @backtrace.select { |r| r.match(@file_path) }.join('').encode('utf-8')
+      @backtrace_message = formatted_backtrace(@example,@exception)
       @highlighted_source = process_source
       @explanation = process_message
     end
@@ -45,8 +46,13 @@ class Oopsy
     )
   end
 
+  def formatted_backtrace(example, exception)
+    formatter = RSpec.configuration.backtrace_formatter
+    formatter.format_backtrace(exception.backtrace, example.metadata)
+  end
+
   def process_source
-    data = @backtrace_message.split(':')
+    data = @backtrace_message[0].split(':')
     unless data.empty?
     if os == :windows
       file_path = data[0] + ':' + data[1]
@@ -88,7 +94,7 @@ class Example
     @status = @execution_result.status.to_s
     @metadata = example.metadata
     @file_path = @metadata[:file_path]
-    @exception = Oopsy.new(example.exception, @file_path)
+    @exception = Oopsy.new(example, @file_path)
     @spec = nil
     @screenshots = @metadata[:screenshots]
     @screenrecord = @metadata[:screenrecord]

--- a/spec/support/steps/turnip_steps.rb
+++ b/spec/support/steps/turnip_steps.rb
@@ -1,20 +1,20 @@
 
-step 'this is when steps' do
+step 'something' do
   # noop
   var = 1
 end
 
-step 'should do success test stuff' do
+step 'it passes' do
   expect('apple').to eq 'apple'
   expect(1).to eq 1
 end
 
-step 'should do pending test stuff' do
+step 'it is pending' do
   pending('coming soon')
   fail
 end
 
-step 'should do assertion error test stuff' do
+step 'it fails' do
   expect('apple').to eq 'apple'
   expect('pear').to eq 1
 end

--- a/spec/turnip.feature
+++ b/spec/turnip.feature
@@ -1,13 +1,13 @@
 Feature: Turnip test cases
 
-  Scenario: Success case
-    When this is when steps
-    Then should do success test stuff
+  Scenario: Pass case
+    When something
+    Then it passes
 
-  Scenario: Pendins case
-    When this is when steps
-    Then should do pending test stuff
+  Scenario: Pending case
+    When something
+    Then it is pending
 
   Scenario: Failure case
-    When this is when steps
-    Then should do assertion error test stuff
+    When something
+    Then it fails

--- a/spec/turnip.feature
+++ b/spec/turnip.feature
@@ -1,0 +1,13 @@
+Feature: Turnip test cases
+
+  Scenario: Success case
+    When this is when steps
+    Then should do success test stuff
+
+  Scenario: Pendins case
+    When this is when steps
+    Then should do pending test stuff
+
+  Scenario: Failure case
+    When this is when steps
+    Then should do assertion error test stuff

--- a/spec/turnip_helper.rb
+++ b/spec/turnip_helper.rb
@@ -1,0 +1,1 @@
+Dir.glob("spec/**/*steps.rb") { |f| load f, true }

--- a/spec/turnip_steps.rb
+++ b/spec/turnip_steps.rb
@@ -1,0 +1,20 @@
+
+step 'this is when steps' do
+  # noop
+  var = 1
+end
+
+step 'should do success test stuff' do
+  expect('apple').to eq 'apple'
+  expect(1).to eq 1
+end
+
+step 'should do pending test stuff' do
+  pending('coming soon')
+  fail
+end
+
+step 'should do assertion error test stuff' do
+  expect('apple').to eq 'apple'
+  expect('pear').to eq 1
+end

--- a/templates/report.erb
+++ b/templates/report.erb
@@ -155,7 +155,16 @@
                         </div>
                         <div class="panel-body">
                           <%= example.exception.explanation %>
-                          <h5><%= example.exception.backtrace_message %></h5>
+                          <dl>
+                            <dt>Backtrace:</dt>
+                            <dd>
+                              <ol>
+                                <% example.exception.backtrace_message.each do |message| %>
+                                  <li><%= message %></li>
+                                <% end %>
+                              </ol>
+                            </dd>
+                          </dl>
                           <%= example.exception.highlighted_source %>
                         </div>
 

--- a/templates/report.erb
+++ b/templates/report.erb
@@ -73,10 +73,7 @@
       </div>
     </div>
 
-  <div class="row">
-
     <div class="col-lg-12">
-
       <table class="table table-striped table-hover ">
         <thead>
         <tr>
@@ -190,10 +187,8 @@
         <% end %>
         </tbody>
       </table>
-
     </div>
   </div>
-
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
### Issue

An issue in using [Turnip](https://github.com/jnicklas/turnip) is that backtrace outputs only feature file's line, although users want to know both step and feature line which caused error.

### What does this pull request do?

To achieve above, changes to use backtrace formatter.

These changes are 
- that backtrace outputs both step and feature line
- modifying html styles slightly
- changing absolute path to relative path ( it is by effect of using backtrace formatter)

### Before
<img width="1166" alt="2018-09-12 11 39 20" src="https://user-images.githubusercontent.com/7259161/45398800-88ae6600-b680-11e8-8af7-5cdba300d3c5.png">

### After
<img width="1140" alt="2018-09-12 11 35 18" src="https://user-images.githubusercontent.com/7259161/45398666-03c34c80-b680-11e8-9fa4-2a8c5b535eed.png">

