### PR TITLE
Fix bugs, avoid an error when throwing  MultipleExceptionError

### DIFF
--- a/lib/rspec_html_reporter.rb
+++ b/lib/rspec_html_reporter.rb
@@ -47,11 +47,14 @@ class Oopsy
   end
 
   def formatted_backtrace(example, exception)
+    # To avoid an error in format_backtrace. RSpec's version below v3.5 will throw exception.
+    return [] unless example
     formatter = RSpec.configuration.backtrace_formatter
     formatter.format_backtrace(exception.backtrace, example.metadata)
   end
 
   def process_source
+    return '' if @backtrace_message.empty?
     data = @backtrace_message.first.split(':')
     unless data.empty?
     if os == :windows

--- a/spec/rspec_html_reporter_spec.rb
+++ b/spec/rspec_html_reporter_spec.rb
@@ -51,5 +51,16 @@ describe 'RSpec HTML Reporter' do
 
   it 'should do insane and cool test stuff' do
     expect('ships').to eq 'ships'
-   end
+  end
+
+  # MultipleExceptionError will be thrown above RSpec v3.3.0
+  describe 'Throw multiple exception' do
+    it "raise error" do
+      raise "This is an exception in test"
+    end
+
+    after :each do
+      raise "This is an exception in after method"
+    end
+  end
 end

--- a/templates/report.erb
+++ b/templates/report.erb
@@ -152,16 +152,18 @@
                         </div>
                         <div class="panel-body">
                           <%= example.exception.explanation %>
-                          <dl>
-                            <dt>Backtrace:</dt>
-                            <dd>
-                              <ol>
-                                <% example.exception.backtrace_message.each do |message| %>
-                                  <li><%= message %></li>
-                                <% end %>
-                              </ol>
-                            </dd>
-                          </dl>
+                          <% unless example.exception.backtrace_message.empty? %>
+                            <dl>
+                              <dt>Backtrace:</dt>
+                              <dd>
+                                <ol>
+                                  <% example.exception.backtrace_message.each do |message| %>
+                                    <li><%= message %></li>
+                                  <% end %>
+                                </ol>
+                              </dd>
+                            </dl>
+                          <% end %>
                           <%= example.exception.highlighted_source %>
                         </div>
 


### PR DESCRIPTION
I have to apologize for injecting a bug. #10 

I notice that rspec above v3.3.0 include MultipleExceptionError which never has backtrace.
When this exception throws, rspec_html_reporter crushed in processing reports.
